### PR TITLE
Update gui_qt_logic.py

### DIFF
--- a/poker/gui/gui_qt_logic.py
+++ b/poker/gui/gui_qt_logic.py
@@ -323,7 +323,7 @@ class UIActionAndSignals(QObject):
         self.genetic_algorithm_form.textBrowser.setText(str(r))
         self.genetic_algorithm_dialog.show()
 
-        self.genetic_algorithm_form.buttonBox.accepted.connect(lambda: GeneticAlgorithm(True, self.logger, l))
+        self.genetic_algorithm_form.buttonBox.accepted.connect(lambda: GeneticAlgorithm(True, self.logger, l)) 
 
     def open_help(self, p, l):
         url = "https://github.com/dickreuter/Poker/wiki/Frequently-asked-questions"


### PR DESCRIPTION
Traceback (most recent call last):
  File "poker\gui\gui_qt_logic.py", line 326, in <lambda>
TypeError: __init__() takes 3 positional arguments but 4 were given

while using the Patrick Edward PS Zoom II strategy and pressing Genetic Algorithm. 
Strategy Analyser also doesnt work for me, but dont now if that is related to this.