### PR TITLE
multiprocessing monte carlo

### DIFF
--- a/poker/decisionmaker/montecarlo_python.py
+++ b/poker/decisionmaker/montecarlo_python.py
@@ -458,7 +458,7 @@ class MonteCarlo(object):
 
 
         try:
-            self.equity = np.round(wins / runs, 3)
+            self.equity = np.round(wins / runs, 4)
         except ZeroDivisionError:
             self.equity = 0.5
             self.logger.warning('MonteCarlo Timeout at Start! runs 0. Setting equity to 0.5')

--- a/poker/decisionmaker/montecarlo_python.py
+++ b/poker/decisionmaker/montecarlo_python.py
@@ -449,7 +449,7 @@ class MonteCarlo(object):
                 none_count += 1
             else:
                 wins += r[0]
-                winnerCardTypeList.append(r[1])
+                if r[0] == 1: winnerCardTypeList.append(r[1])
 
         runs = maxRuns - none_count
         if none_count > 0:

--- a/poker/main.py
+++ b/poker/main.py
@@ -2,6 +2,8 @@ import warnings
 
 import matplotlib.cbook
 
+from poker.tools.pool_manager import PoolManager
+
 warnings.filterwarnings("ignore", category=matplotlib.cbook.mplDeprecation)
 warnings.filterwarnings("ignore", message="ignoring `maxfev` argument to `Minimizer()`. Use `max_nfev` instead.")
 warnings.filterwarnings("ignore", message="DataFrame columns are not unique, some columns will be omitted.")
@@ -126,6 +128,10 @@ class ThreadManager(threading.Thread):
 
         preflop_state = CurrentHandPreflopState()
         mongo = MongoManager()
+
+        pm = PoolManager()
+        pm.init_pool()  # init pool and keep the pool alive, load overhead only once
+
         table_scraper_name = None
 
         while True:
@@ -232,6 +238,11 @@ class ThreadManager(threading.Thread):
                 log.info("=========== round end ===========")
 
 
+def clean_up():
+    pm = PoolManager()
+    pm.shutdown()
+
+
 # ==== MAIN PROGRAM =====
 
 def run_poker():
@@ -262,6 +273,7 @@ def run_poker():
     sys.__excepthook__ = exception_hook
 
     app = QtWidgets.QApplication(sys.argv)
+    app.aboutToQuit.connect(clean_up)
     MainWindow = QtWidgets.QMainWindow()
 
     ui = Ui_Pokerbot()

--- a/poker/tools/pool_manager.py
+++ b/poker/tools/pool_manager.py
@@ -1,0 +1,31 @@
+import multiprocessing as mp
+
+
+class Singleton(type):
+    def __init__(cls, name, bases, dict):
+        super(Singleton, cls).__init__(name, bases, dict)
+        cls.instance = None
+
+    def __call__(cls, *args, **kw):
+        if cls.instance is None:
+            cls.instance = super(Singleton, cls).__call__(*args, **kw)
+        return cls.instance
+
+
+def foo(index):
+    pass
+
+
+class PoolManager(metaclass=Singleton):
+    def __init__(self):
+        self.pool = mp.Pool(4)
+
+    def get(self):
+        return self.pool
+
+    def init_pool(self):
+        self.pool.map(foo, range(100))
+
+    def shutdown(self):
+        self.pool.close()
+        self.pool.join()


### PR DESCRIPTION
Solved the overhead timeout issue by initiating pool at first, which is wrapped in a singleton. Tested on different OS.

Need to init the `PoolManager` first to load overhead if in unit test. As working with full bot it's been written in main.py