### PR TITLE
Table setup enhancements

### DIFF
--- a/poker/.pylintrc
+++ b/poker/.pylintrc
@@ -180,7 +180,8 @@ disable=print-statement,
         consider-using-sys-exit,
         no-else-return,
         cyclic-import,
-        too-many-instance-attributes
+        too-many-instance-attributes,
+        unspecified-encoding
 
 
 

--- a/poker/config.ini
+++ b/poker/config.ini
@@ -8,3 +8,4 @@ table_scraper_name = Official Party Poker
 login = guest
 password = guest
 db = http://dickreuter.com:7777/
+

--- a/poker/decisionmaker/current_hand_memory.py
+++ b/poker/decisionmaker/current_hand_memory.py
@@ -57,8 +57,8 @@ class CurrentHandPreflopState:
 
         self.bot_preflop_position_utg = t.position_utg_plus
         self.bot_preflop_decision = decision_str
-        self.preflop_sheet_name = t.preflop_sheet_name
-        self.preflop_bot_ranges = d.preflop_bot_ranges
+        self.preflop_sheet_name = getattr(t, 'preflop_sheet_name', None)
+        self.preflop_bot_ranges = getattr(d, 'preflop_bot_ranges', None)
 
         self.rounds = h.round_number
         if not np.isnan(t.first_raiser_utg):

--- a/poker/decisionmaker/genetic_algorithm.py
+++ b/poker/decisionmaker/genetic_algorithm.py
@@ -1,6 +1,6 @@
-'''
+"""
 Assesses the log file and checks how the parameters in strategies.xml need to be adjusted to optimize playing
-'''
+"""
 import logging
 
 from poker.tools.game_logger import GameLogger
@@ -33,7 +33,7 @@ class GeneticAlgorithm:
     def load_log(self, p_name, L):
         self.gameResults = {}
         L.get_stacked_bar_data('Template', p_name, 'stackedBar')
-        self.recommendation = dict()
+        self.recommendation = {}
 
     def assess_call(self, p, L, decision, stage, coeff1, coeff2, coeff3, coeff4, change):
         A = L.d[decision, stage, 'Won'] > L.d[decision, stage, 'Lost'] * coeff1  # Call won > call lost * c1

--- a/poker/gui/ui/table_setup_form.ui
+++ b/poker/gui/ui/table_setup_form.ui
@@ -776,8 +776,18 @@
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_2">
-                <item>
+               <layout class="QGridLayout" name="gridLayout_21" columnminimumwidth="240,0">
+                <item row="1" column="0">
+                 <widget class="QPushButton" name="right_card_area">
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exact location of the card the bot is holding. This should be as close to the same size as the card templates so it's easier for recognition with neural network. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="text">
+                   <string>Right Card Area</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
                  <widget class="QPushButton" name="left_card_area">
                   <property name="baseSize">
                    <size>
@@ -793,23 +803,21 @@
                   </property>
                  </widget>
                 </item>
-                <item>
-                 <widget class="QPushButton" name="right_card_area">
-                  <property name="toolTip">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Exact location of the card the bot is holding. This should be as close to the same size as the card templates so it's easier for recognition with neural network. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                  </property>
+                <item row="0" column="1">
+                 <widget class="QPushButton" name="left_card_area_show">
                   <property name="text">
-                   <string>Right Card Area</string>
+                   <string>Show</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QPushButton" name="right_card_area_show">
+                  <property name="text">
+                   <string>Show</string>
                   </property>
                  </widget>
                 </item>
                </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_9"/>
-              </item>
-              <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_10"/>
               </item>
              </layout>
             </item>
@@ -2414,7 +2422,7 @@
                 </layout>
                </item>
                <item>
-                <layout class="QGridLayout" name="gridLayout_20">
+                <layout class="QGridLayout" name="gridLayout_20" columnminimumwidth="220,0">
                  <item row="0" column="0">
                   <widget class="QPushButton" name="covered_card">
                    <property name="toolTip">
@@ -2501,14 +2509,92 @@
               <property name="title">
                <string>Mouse Control</string>
               </property>
-              <layout class="QGridLayout" name="gridLayout_2">
-               <item row="9" column="0">
-                <widget class="QPushButton" name="mouse_imback">
+              <layout class="QGridLayout" name="gridLayout_2" columnminimumwidth="240,0">
+               <item row="0" column="0">
+                <widget class="QPushButton" name="mouse_fold">
                  <property name="toolTip">
-                  <string>Location of I'm back button</string>
+                  <string>Area of fold button to click</string>
                  </property>
                  <property name="text">
-                  <string>I'm back</string>
+                  <string>Fold</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QPushButton" name="mouse_fold_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QPushButton" name="mouse_raise">
+                 <property name="text">
+                  <string>Raise</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QPushButton" name="mouse_raise_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QPushButton" name="mouse_half_pot">
+                 <property name="text">
+                  <string>Half pot</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QPushButton" name="mouse_half_pot_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QPushButton" name="mouse_full_pot">
+                 <property name="text">
+                  <string>Full pot</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QPushButton" name="mouse_full_pot_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QPushButton" name="mouse_call">
+                 <property name="text">
+                  <string>Call</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QPushButton" name="mouse_call_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
                  </property>
                 </widget>
                </item>
@@ -2522,34 +2608,47 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="0">
-                <widget class="QPushButton" name="mouse_fold">
-                 <property name="toolTip">
-                  <string>Area of fold button to click</string>
+               <item row="5" column="1">
+                <widget class="QPushButton" name="mouse_call2_show">
+                 <property name="enabled">
+                  <bool>false</bool>
                  </property>
                  <property name="text">
-                  <string>Fold</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QPushButton" name="mouse_half_pot">
-                 <property name="text">
-                  <string>Half pot</string>
+                  <string>Show</string>
                  </property>
                 </widget>
                </item>
-               <item row="11" column="0">
-                <widget class="QPushButton" name="mouse_increase">
+               <item row="6" column="0">
+                <widget class="QPushButton" name="mouse_fast_fold">
                  <property name="text">
-                  <string>Increase</string>
+                  <string>Fast Fold</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0">
-                <widget class="QPushButton" name="mouse_call">
+               <item row="6" column="1">
+                <widget class="QPushButton" name="mouse_fast_fold_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
                  <property name="text">
-                  <string>Call</string>
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QPushButton" name="mouse_all_in">
+                 <property name="text">
+                  <string>All In</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="1">
+                <widget class="QPushButton" name="mouse_all_in_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
                  </property>
                 </widget>
                </item>
@@ -2563,10 +2662,67 @@
                  </property>
                 </widget>
                </item>
-               <item row="7" column="0">
-                <widget class="QPushButton" name="mouse_all_in">
+               <item row="8" column="1">
+                <widget class="QPushButton" name="mouse_check_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
                  <property name="text">
-                  <string>All In</string>
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="0">
+                <widget class="QPushButton" name="mouse_imback">
+                 <property name="toolTip">
+                  <string>Location of I'm back button</string>
+                 </property>
+                 <property name="text">
+                  <string>I'm back</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="9" column="1">
+                <widget class="QPushButton" name="mouse_imback_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="0">
+                <widget class="QPushButton" name="mouse_resume_hand">
+                 <property name="text">
+                  <string>Resume Hand</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <widget class="QPushButton" name="mouse_resume_hand_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="0">
+                <widget class="QPushButton" name="mouse_increase">
+                 <property name="text">
+                  <string>Increase</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="1">
+                <widget class="QPushButton" name="mouse_increase_show">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Show</string>
                  </property>
                 </widget>
                </item>
@@ -2582,34 +2738,6 @@
                   </size>
                  </property>
                 </spacer>
-               </item>
-               <item row="1" column="0">
-                <widget class="QPushButton" name="mouse_raise">
-                 <property name="text">
-                  <string>Raise</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QPushButton" name="mouse_full_pot">
-                 <property name="text">
-                  <string>Full pot</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QPushButton" name="mouse_fast_fold">
-                 <property name="text">
-                  <string>Fast Fold</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QPushButton" name="mouse_resume_hand">
-                 <property name="text">
-                  <string>Resume Hand</string>
-                 </property>
-                </widget>
                </item>
               </layout>
              </widget>
@@ -2918,7 +3046,7 @@ Then check the console output for error messages.</string>
                 <property name="text">
                  <string>Drop image here
 
-Or take screenshot via button above</string>
+Or take screenshot via the button above</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>

--- a/poker/gui/ui/table_setup_form.ui
+++ b/poker/gui/ui/table_setup_form.ui
@@ -91,6 +91,16 @@
                      </property>
                     </widget>
                    </item>
+                   <item row="8" column="1">
+                    <widget class="QPushButton" name="my_turn_search_area_show">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="text">
+                      <string>Show</string>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="13" column="1">
                     <widget class="QPushButton" name="resume_hand_show">
                      <property name="enabled">
@@ -228,6 +238,16 @@
                      </property>
                     </widget>
                    </item>
+                   <item row="10" column="1">
+                    <widget class="QPushButton" name="lost_everything_search_area_show">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="text">
+                      <string>Show</string>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="11" column="0">
                     <widget class="QPushButton" name="lost_everything">
                      <property name="toolTip">
@@ -245,6 +265,16 @@
                      </property>
                      <property name="text">
                       <string>Buttons search area</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <widget class="QPushButton" name="buttons_search_area_show">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="text">
+                      <string>Show</string>
                      </property>
                     </widget>
                    </item>
@@ -315,7 +345,7 @@
                  <string>Search areas for cards</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_4">
-                 <item row="1" column="0">
+                 <item row="0" column="0">
                   <widget class="QPushButton" name="table_cards_area">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -331,13 +361,33 @@
                    </property>
                   </widget>
                  </item>
-                 <item row="3" column="0">
+                 <item row="0" column="1">
+                  <widget class="QPushButton" name="table_cards_area_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
                   <widget class="QPushButton" name="my_cards_area">
                    <property name="toolTip">
                     <string>Area where the player holds his cards</string>
                    </property>
                    <property name="text">
                     <string>My Cards area</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QPushButton" name="my_cards_area_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
                    </property>
                   </widget>
                  </item>
@@ -360,6 +410,16 @@
                    </property>
                   </widget>
                  </item>
+                 <item row="0" column="1">
+                  <widget class="QPushButton" name="game_number_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
+                   </property>
+                  </widget>
+                 </item>
                  <item row="1" column="0">
                   <widget class="QPushButton" name="all_in_call_value">
                    <property name="toolTip">
@@ -370,6 +430,16 @@
                    </property>
                   </widget>
                  </item>
+                 <item row="1" column="1">
+                  <widget class="QPushButton" name="all_in_call_value_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
+                   </property>
+                  </widget>
+                 </item>
                  <item row="2" column="0">
                   <widget class="QPushButton" name="call_value">
                    <property name="toolTip">
@@ -377,6 +447,16 @@
                    </property>
                    <property name="text">
                     <string>Call value</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QPushButton" name="call_value_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
                    </property>
                   </widget>
                  </item>
@@ -393,6 +473,16 @@
                    </property>
                   </widget>
                  </item>
+                 <item row="3" column="1">
+                  <widget class="QPushButton" name="raise_value_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
+                   </property>
+                  </widget>
+                 </item>
                  <item row="5" column="0">
                   <widget class="QPushButton" name="current_round_pot">
                    <property name="toolTip">
@@ -400,6 +490,16 @@
                    </property>
                    <property name="text">
                     <string>Current Round Pot value</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="5" column="1">
+                  <widget class="QPushButton" name="current_round_pot_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
                    </property>
                   </widget>
                  </item>
@@ -416,6 +516,16 @@
                    </property>
                    <property name="text">
                     <string>Total Pot value</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="6" column="1">
+                  <widget class="QPushButton" name="total_pot_area_show">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="text">
+                    <string>Show</string>
                    </property>
                   </widget>
                  </item>

--- a/poker/gui/ui/table_setup_form.ui
+++ b/poker/gui/ui/table_setup_form.ui
@@ -2781,7 +2781,7 @@ Then check the console output for error messages.</string>
             <property name="widgetResizable">
              <bool>true</bool>
             </property>
-            <widget class="QWidget" name="scrollAreaWidgetContents_2">
+            <widget class="QWidget" name="screenshot_widget">
              <property name="geometry">
               <rect>
                <x>0</x>
@@ -2789,6 +2789,9 @@ Then check the console output for error messages.</string>
                <width>826</width>
                <height>558</height>
               </rect>
+             </property>
+             <property name="acceptDrops">
+              <bool>true</bool>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_3">
               <item>
@@ -2799,8 +2802,16 @@ Then check the console output for error messages.</string>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
+                <property name="styleSheet">
+                 <string notr="true">border: 4px dashed #aaa</string>
+                </property>
                 <property name="text">
-                 <string/>
+                 <string>Drop image here
+
+Or take screenshot via button above</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
                 </property>
                </widget>
               </item>

--- a/poker/scraper/table_screen_based.py
+++ b/poker/scraper/table_screen_based.py
@@ -226,13 +226,14 @@ class TableScreenBased(Table):
             return False
 
     def init_get_other_players_info(self):
-        other_player = dict()
-        other_player['utg_position'] = ''
-        other_player['name'] = ''
-        other_player['status'] = ''
-        other_player['funds'] = ''
-        other_player['pot'] = ''
-        other_player['decision'] = ''
+        other_player = {
+            'utg_position': '',
+            'name': '',
+            'status': '',
+            'funds': '',
+            'pot': '',
+            'decision': ''
+        }
         self.other_players = []
         for i in range(self.total_players - 1):
             self.gui_signals.signal_status.emit(f"Check other players {i}")

--- a/poker/scraper/table_setup_actions_and_signals.py
+++ b/poker/scraper/table_setup_actions_and_signals.py
@@ -262,7 +262,7 @@ class TableSetupActionAndSignals(QObject):
                 log.error(f"Missing table entry for {label} {player}. "
                           f"Please select it from the screenshot and press the corresponding button to add it to the "
                           f"table template. ")
-                return 0
+                return
         else:
             search_area = table_dict[label]
 

--- a/poker/scraper/table_setup_actions_and_signals.py
+++ b/poker/scraper/table_setup_actions_and_signals.py
@@ -99,8 +99,8 @@ class TableSetupActionAndSignals(QObject):
         log.info("Saving complete")
 
     def _connect_cards_with_save_slot(self):
-        deck = []  # contains cards in the deck
-        _ = [deck.append(x.lower() + y.lower()) for x in CARD_VALUES for y in CARD_SUITES]
+        # contains cards in the deck
+        deck = [x.lower() + y.lower() for x in CARD_VALUES for y in CARD_SUITES]
 
         for card in deck:
             button_property = getattr(self.ui, 'card_' + card)
@@ -128,15 +128,25 @@ class TableSetupActionAndSignals(QObject):
         button_show_property.clicked.connect(lambda state: self.load_image('covered_card'))
 
     def _connect_range_buttons_with_save_coordinates(self):
-        range_buttons = ['call_value', 'raise_value', 'all_in_call_value', 'game_number', 'current_round_pot',
-                         'total_pot_area', 'my_turn_search_area', 'lost_everything_search_area',
-                         'table_cards_area', 'my_cards_area',
-                         'mouse_fold', 'mouse_fast_fold', 'mouse_raise', 'mouse_full_pot', 'mouse_call',
-                         'mouse_increase', 'mouse_call2', 'mouse_check',
-                         'mouse_imback',
-                         'mouse_half_pot', 'mouse_all_in', 'mouse_resume_hand', 'buttons_search_area',
-                         'left_card_area', 'right_card_area'
-                         ]
+        range_buttons = [
+            'call_value', 'raise_value', 'all_in_call_value', 'game_number', 'current_round_pot',
+            'total_pot_area', 'my_turn_search_area', 'lost_everything_search_area',
+            'table_cards_area', 'my_cards_area', 'buttons_search_area',
+        ]
+
+        for button in range_buttons:
+            button_property = getattr(self.ui, button)
+            button_property.clicked.connect(lambda state, x=button: self.save_coordinates(x))
+
+            button_show_property = getattr(self.ui, button + '_show')
+            button_show_property.clicked.connect(lambda state, x=button: self.show_coordinates(x))
+
+        range_buttons = [
+            'mouse_fold', 'mouse_fast_fold', 'mouse_raise', 'mouse_full_pot', 'mouse_call',
+            'mouse_increase', 'mouse_call2', 'mouse_check', 'mouse_imback',
+            'mouse_half_pot', 'mouse_all_in', 'mouse_resume_hand',
+            'left_card_area', 'right_card_area'
+        ]
 
         for button in range_buttons:
             button_property = getattr(self.ui, button)
@@ -148,6 +158,9 @@ class TableSetupActionAndSignals(QObject):
         for button in range_buttons:
             button_property = getattr(self.ui, button)
             button_property.clicked.connect(lambda state, x=button: self.save_coordinates(x, self.selected_player))
+
+            button_show_property = getattr(self.ui, button + '_show')
+            button_show_property.clicked.connect(lambda state, x=button: self.show_coordinates(x, self.selected_player))
 
     def save_topleft_corner(self):
         self.table_name = self.ui.table_name.currentText()
@@ -218,13 +231,10 @@ class TableSetupActionAndSignals(QObject):
             except AttributeError:
                 log.info(f"Ignoring flattening of {button_name}")
 
-            excluded_buttons = ['topleft_corner', 'game_number', 'call_value', 'raise_value', 'all_in_call_value',
-                                'my_turn_search_area', 'lost_everything_search_area',
-                                'mouse_fold', 'mouse_fast_fold', 'mouse_raise', 'mouse_full_pot', 'mouse_call',
+            excluded_buttons = ['mouse_fold', 'mouse_fast_fold', 'mouse_raise', 'mouse_full_pot', 'mouse_call',
                                 'mouse_increase', 'mouse_resume_hand', 'mouse_call2', 'mouse_check', 'mouse_imback',
-                                'mouse_half_pot', 'table_cards_area', 'current_round_pot', 'total_pot_area',
-                                'my_cards_area', 'right_card_area', 'left_card_area', 'top_cards_top_area',
-                                'mouse_all_in', 'buttons_search_area', 'use_neural_network']
+                                'mouse_half_pot', 'mouse_all_in', 'right_card_area', 'left_card_area',
+                                'use_neural_network']
             if button_name not in excluded_buttons:
                 button = getattr(self.ui, button_name + '_show')
                 button.setEnabled(checked)
@@ -244,6 +254,32 @@ class TableSetupActionAndSignals(QObject):
             self.ui.table_name.setCurrentIndex(self.ui.table_name.count() - 1)
         else:
             pop_up("Unable to create new table with that name", "Please choose a different name.")
+
+    @pyqtSlot(object, str, str)
+    def show_coordinates(self, label, player=None):
+        if not self.cropped:
+            pop_up("Image not yet cropped",
+                   "Before you can load image by coordinates, "
+                   "you need to mark or load a top left corner, then crop the image.")
+            return
+
+        self.table_name = self.ui.table_name.currentText()
+        table_dict = mongo.get_table(table_name=self.table_name)
+        if player:
+            try:
+                search_area = table_dict[label][player]
+            except KeyError:
+                log.error(f"Missing table entry for {label} {player}. "
+                          f"Please select it from the screenshot and press the corresponding button to add it to the "
+                          f"table template. ")
+                return 0
+        else:
+            search_area = table_dict[label]
+
+        x1, y1, x2, y2 = search_area['x1'], search_area['y1'], search_area['x2'], search_area['y2']
+        self.preview = self.original_screenshot.crop((x1, y1, x2, y2))
+        log.info("image cropped")
+        self._update_preview_label(self.preview)
 
     @pyqtSlot(object, str, str)
     def save_coordinates(self, label, player=None):
@@ -451,8 +487,8 @@ class TableSetupActionAndSignals(QObject):
         self.table_name = self.ui.table_name.currentText()
 
         # unflatten buttons and disable 'show' buttons
-        deck = []  # contains cards in the deck
-        _ = [deck.append(x.lower() + y.lower()) for x in CARD_VALUES for y in CARD_SUITES]
+        # contains cards in the deck
+        deck = [x.lower() + y.lower() for x in CARD_VALUES for y in CARD_SUITES]
 
         for card in deck:
             log.info(f"UnFlattening button {'card_' + card}")

--- a/poker/scraper/table_setup_actions_and_signals.py
+++ b/poker/scraper/table_setup_actions_and_signals.py
@@ -1,4 +1,5 @@
 """Learn to read a table"""
+import io
 import logging
 import time
 
@@ -132,16 +133,6 @@ class TableSetupActionAndSignals(QObject):
             'call_value', 'raise_value', 'all_in_call_value', 'game_number', 'current_round_pot',
             'total_pot_area', 'my_turn_search_area', 'lost_everything_search_area',
             'table_cards_area', 'my_cards_area', 'buttons_search_area',
-        ]
-
-        for button in range_buttons:
-            button_property = getattr(self.ui, button)
-            button_property.clicked.connect(lambda state, x=button: self.save_coordinates(x))
-
-            button_show_property = getattr(self.ui, button + '_show')
-            button_show_property.clicked.connect(lambda state, x=button: self.show_coordinates(x))
-
-        range_buttons = [
             'mouse_fold', 'mouse_fast_fold', 'mouse_raise', 'mouse_full_pot', 'mouse_call',
             'mouse_increase', 'mouse_call2', 'mouse_check', 'mouse_imback',
             'mouse_half_pot', 'mouse_all_in', 'mouse_resume_hand',
@@ -151,6 +142,9 @@ class TableSetupActionAndSignals(QObject):
         for button in range_buttons:
             button_property = getattr(self.ui, button)
             button_property.clicked.connect(lambda state, x=button: self.save_coordinates(x))
+
+            button_show_property = getattr(self.ui, button + '_show')
+            button_show_property.clicked.connect(lambda state, x=button: self.show_coordinates(x))
 
         # range buttons for each players
         range_buttons = ['covered_card_area', 'player_name_area', 'player_funds_area', 'player_pot_area',
@@ -231,11 +225,7 @@ class TableSetupActionAndSignals(QObject):
             except AttributeError:
                 log.info(f"Ignoring flattening of {button_name}")
 
-            excluded_buttons = ['mouse_fold', 'mouse_fast_fold', 'mouse_raise', 'mouse_full_pot', 'mouse_call',
-                                'mouse_increase', 'mouse_resume_hand', 'mouse_call2', 'mouse_check', 'mouse_imback',
-                                'mouse_half_pot', 'mouse_all_in', 'right_card_area', 'left_card_area',
-                                'use_neural_network']
-            if button_name not in excluded_buttons:
+            if button_name != 'use_neural_network':
                 button = getattr(self.ui, button_name + '_show')
                 button.setEnabled(checked)
 
@@ -514,6 +504,10 @@ class TableSetupActionAndSignals(QObject):
         log.info(f"Loading table {self.table_name}")
         table = mongo.get_table(table_name=self.table_name)
         log.info(table.keys())
+
+        # show topleft_corner image in preview
+        self.preview = Image.open(io.BytesIO(table['topleft_corner']))
+        self._update_preview_label(self.preview)
 
         check_boxes = ['use_neural_network']
         for check_box in check_boxes:

--- a/poker/tools/game_logger.py
+++ b/poker/tools/game_logger.py
@@ -18,7 +18,7 @@ URL = config.config.get('main', 'db')
 
 class GameLogger(metaclass=Singleton):
     def __init__(self):
-        self.d = dict()  # TODO: refactor it
+        self.d = {}  # TODO: refactor it
         self.FinalDataFrame = None
 
     def clean_database(self):
@@ -89,15 +89,15 @@ class GameLogger(metaclass=Singleton):
             h.totalGames += 1
         if h.histGameStage != '':
 
-            summary_dict = dict()
-            summary_dict['rounds'] = []
+            summary_dict = {'rounds': []}
             i = 0
             mongo = MongoManager()
             rounds = mongo.get_rounds(h.lastGameID)
             for _round in rounds:
-                round_name_value = dict()
-                round_name_value['round_number'] = str(i)
-                round_name_value['round_values'] = _round
+                round_name_value = {
+                    'round_number': str(i),
+                    'round_values': _round
+                }
                 summary_dict['rounds'].append(round_name_value)
                 i += 1
 


### PR DESCRIPTION
- Added feature to load screenshot from host PC via drag'n'drop. So we can load screenshots from log folder.
- Added show buttons for all search areas. If the screenshot is loaded, it shows the image cropped with such coordinates. Useful for debugging.
- After clicking on `Load template`, `top_left_corner` image is shown. Useful for debugging.
- Refactored a bit `decisionmaker.py`. But didn't change any logic.

![anydesk00004](https://user-images.githubusercontent.com/93276556/140076009-0ac82596-bf32-4a91-b509-2ba7b13a853c.png)
