### PR TITLE
ci: install `tesserocr` from wheel in Windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Install Tesseract
         run: |
-          iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl -Out tesserocr.whl
-          pip install ./tesserocr.whl
+          iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl -Out tesserocr-2.6.0-cp311-cp311-win_amd64.whl
+          pip install tesserocr-2.6.0-cp311-cp311-win_amd64.whl
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Tesseract
         run: |
           iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl -Out tesserocr.whl
-          pip install tesserocr.whl
+          pip install ./tesserocr.whl
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,12 +9,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
+          cache: pip
 
       - name: Install Tesseract
         run: |
@@ -22,8 +26,7 @@ jobs:
           pip install tesserocr-2.6.0-cp311-cp311-win_amd64.whl
 
       - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Run PyInstaller
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,55 +10,34 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.11.5'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11.5'
 
-    - name: Install Tesseract
-      run: |
-        choco install tesseract
-        echo "C:\Program Files\Tesseract-OCR" >> $GITHUB_PATH
+      - name: Install Tesseract
+        run: iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl
 
-    - name: Refresh Environment
-      run: |
-        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
-        Update-SessionEnvironment
+      - name: Install dependencies
+        run: pip install -r requirements.txt
 
-    - name: Check PATH
-      run: |
-        echo "PATH: $env:PATH"
+      - name: Run PyInstaller
+        run: |
+          cd poker
+          pyinstaller main.spec
+          # Add other necessary steps here
 
-    - name: List Tesseract Directory
-      run: |
-        ls "C:\Program Files\Tesseract-OCR"
+      - name: Install NSIS
+        run: |
+          choco install nsis
 
-    - name: Test Tesseract Command
-      run: |
-        & "C:\Program Files\Tesseract-OCR\tesseract.exe" --version
+      - name: Run NSIS
+        run: makensis -V3 DeepMindPokerbot.nsi
 
-    - name: Install dependencies
-      run: |
-        $env:Path += ";C:\Program Files\Tesseract-OCR"
-        pip install -r requirements.txt
-
-    - name: Run PyInstaller
-      run: |
-        cd poker
-        pyinstaller main.spec
-        # Add other necessary steps here
-
-    - name: Install NSIS
-      run: |
-        choco install nsis
-
-    - name: Run NSIS
-      run: makensis -V3 DeepMindPokerbot.nsi
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: compiled-app
-        path: path/to/your/compiled/app
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: compiled-app
+          path: path/to/your/compiled/app

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11.5
+          python-version: 3.11
 
       - name: Install Tesseract
         run: |
-          iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl
-          pip install tesserocr-2.6.0-cp311-cp311-win_amd64.whl
+          iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl -Out tesserocr.whl
+          pip install tesserocr.whl
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,20 +2,19 @@ name: Windows Build
 
 on:
   push:
-    branches:
-      - master
+    branches: master
 
 jobs:
   build:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.11.5'
+          python-version: 3.11.5
 
       - name: Install Tesseract
         run: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -18,10 +18,13 @@ jobs:
           python-version: '3.11.5'
 
       - name: Install Tesseract
-        run: iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl
+        run: |
+          iwr https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.6.0-tesseract-5.3.1/tesserocr-2.6.0-cp311-cp311-win_amd64.whl
+          pip install tesserocr-2.6.0-cp311-cp311-win_amd64.whl
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
 
       - name: Run PyInstaller
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,3 @@ PyJWT==1.7.0
 flask_jwt_extended
 fastapi_auth
 uvicorn
-tesserocr

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ PyJWT==1.7.0
 flask_jwt_extended
 fastapi_auth
 uvicorn
+tesserocr


### PR DESCRIPTION
# Summary

- Pull wheel directly from GitHub using `iwr`
- Update outdated actions
- Use cached Python version for faster builds